### PR TITLE
商品一覧機能表示

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,12 +7,12 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
+      <% if @item.order.present? %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">


### PR DESCRIPTION
商品出品機能実装
　＃What
　　1: 出品した商品一覧表示作成
　　2: ログアウト時の商品一覧表示確認
　　3: 新しい商品が上に表示の確認
　　4: 売却済み商品の『sold out』の表示（未確認） 
https://i.gyazo.com/913bd3c920314b8f55e4aa884cb9051b.mp4
https://i.gyazo.com/32e1fe241080586cdf1fb20b2f31d3ca.mp4
　#Why
　　1:トップページで商品一覧を表示するため

※前回で出品確認をするためにトップページへの表示をしていました。
