### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,6 +10,11 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new    
   end
+
+  def show  
+    @item = Item.find(params[:id])
+  end
+  
   
   def create
     @item = Item.new(items_params)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
 
   before_action :login_check, only: [:edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit]
+
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -9,10 +11,6 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new    
-  end
-
-  def show  
-    @item = Item.find(params[:id])
   end
   
   
@@ -38,5 +36,9 @@ class ItemsController < ApplicationController
       flash[:alert] = 'ログインしてください'
       redirect_to root_path
     end
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,11 +125,9 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
       <% @items.each do |item| %>
-        <%= link_to items_path(item.id) do %>
+        <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" if item.image.attached? %>
             <% if item.order.present?%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= "#{@item.product_name}" %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
@@ -16,53 +16,50 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥#{@item.price}" %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', edit_order_path(@item), method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %> 
+    <% else %>
+    <% unless @item.order.present? %>
+      <%= link_to '購入画面に進む', new_order_path(@item), method: :get, class:"item-red-btn"%>
+    <% end %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= "#{@item.product_name}" %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
-          <th class="detail-item">出品者</th>
+          <th class="detail-item"><%= "#{@item.user.nickname}" %></th>
           <td class="detail-value"><%= "出品者名" %></td>
         </tr>
         <tr>
-          <th class="detail-item">カテゴリー</th>
+          <th class="detail-item"><%= "#{@item.category.name}" %></th>
           <td class="detail-value"><%= "カテゴリー名" %></td>
         </tr>
         <tr>
-          <th class="detail-item">商品の状態</th>
+          <th class="detail-item"><%= "#{@item.state.name}" %></th>
           <td class="detail-value"><%= "商品の状態" %></td>
         </tr>
         <tr>
-          <th class="detail-item">配送料の負担</th>
+          <th class="detail-item"><%= "#{@item.postage.name}" %></th>
           <td class="detail-value"><%= "発送料の負担" %></td>
         </tr>
         <tr>
-          <th class="detail-item">発送元の地域</th>
+          <th class="detail-item"><%= "#{@item.region.name}" %></th>
           <td class="detail-value"><%= "発送元の地域" %></td>
         </tr>
         <tr>
-          <th class="detail-item">発送日の目安</th>
+          <th class="detail-item"><%= "#{@item.shipping_time.name}" %></th>
           <td class="detail-value"><%= "発送日の目安" %></td>
         </tr>
       </tbody>
@@ -102,7 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= "#{@item.category.name}" %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <%= link_to '商品の編集', edit_order_path(@item), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %> 
-    <% elsif @item.order.present? %>
+      <% elsif user_signed_in? &&@item.order.present? %>
       <%= link_to '購入画面に進む', new_order_path(@item), method: :get, class:"item-red-btn"%>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,10 +27,8 @@
       <%= link_to '商品の編集', edit_order_path(@item), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %> 
-    <% else %>
-    <% unless @item.order.present? %>
+    <% elsif @item.order.present? %>
       <%= link_to '購入画面に進む', new_order_path(@item), method: :get, class:"item-red-btn"%>
-    <% end %>
     <% end %>
 
     <div class="item-explain-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items,only: [:new, :create, :index]
+  resources :items,only: [:new, :create, :index, :show]
   resources :orders
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
商品詳細表示機能実装
#what
　1: 商品詳細表示作成
　2: ログイン時の商品詳細表示の『編集/削除』ボタンの実装
   3: ログイン時の他ユーザーの商品詳細表示の『商品購入』ボタンの実装
   4: 非ログイン時の商品詳細表示の『編集/削除/商品購入』ボタンの未実装
　5: 売却済み商品の『sold out』の表示（未確認）
ログイン時:https://i.gyazo.com/6e36517f9cad12d805d62ff2092b62b6.mp4
他ユーザー:https://i.gyazo.com/1dc68c9feb5452e724f9c3e7b88712b9.mp4
非ログイン時:https://i.gyazo.com/325aadff15817591c134d6f446844d76.mp4

#why
   1:各パターン(ログイン時、他ユーザー、非ログイン時)の商品詳細ページを表示するため